### PR TITLE
Fix for accessing static property non-static

### DIFF
--- a/class.jorttbv.php
+++ b/class.jorttbv.php
@@ -14,8 +14,8 @@
 		protected static $appurl = 'https://app.jortt.nl/api/';
 
 		public function __construct($appname, $apptoken) {
-			$this->appname = $appname;
-			$this->apptoken = $apptoken;
+			self::$appname = $appname;
+			self::$apptoken = $apptoken;
 		}
 
 		public static function request($string, $select) {


### PR DESCRIPTION
Throws a Strict Standards error in PHP 5.6